### PR TITLE
Fish-10295: patching weld to fix tck issues

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -30,7 +30,7 @@
     </developers>
 
     <properties>
-        <weld.api.bom.version>5.0.SP2</weld.api.bom.version>
+        <weld.api.bom.version>5.0.SP3</weld.api.bom.version>
         <gpg.plugin.version>3.0.1</gpg.plugin.version>
         <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
         <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.jboss.weld</groupId>
     <artifactId>weld-core-bom</artifactId>
     <packaging>pom</packaging>
-    <version>5.0.1.payara-p1-SNAPSHOT</version>
+    <version>5.0.1.payara-p1</version>
 
     <name>Weld Core BOM</name>
 
@@ -126,7 +126,7 @@
         <connection>scm:git:git@github.com:weld/core.git</connection>
         <developerConnection>scm:git:git@github.com:weld/core.git</developerConnection>
         <url>scm:git:git@github.com:weld/core.git</url>
-        <tag>5.0.1.payara-p1-SNAPSHOT</tag>
+        <tag>5.0.1.payara-p1</tag>
     </scm>
 
     <profiles>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.jboss.weld</groupId>
     <artifactId>weld-core-bom</artifactId>
     <packaging>pom</packaging>
-    <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+    <version>5.0.1.payara-p1-SNAPSHOT</version>
 
     <name>Weld Core BOM</name>
 
@@ -126,7 +126,7 @@
         <connection>scm:git:git@github.com:weld/core.git</connection>
         <developerConnection>scm:git:git@github.com:weld/core.git</developerConnection>
         <url>scm:git:git@github.com:weld/core.git</url>
-        <tag>5.0.1.Final.payara-p1-SNAPSHOT</tag>
+        <tag>5.0.1.payara-p1-SNAPSHOT</tag>
     </scm>
 
     <profiles>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.jboss.weld</groupId>
     <artifactId>weld-core-bom</artifactId>
     <packaging>pom</packaging>
-    <version>5.0.1.Final</version>
+    <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
 
     <name>Weld Core BOM</name>
 
@@ -126,7 +126,7 @@
         <connection>scm:git:git@github.com:weld/core.git</connection>
         <developerConnection>scm:git:git@github.com:weld/core.git</developerConnection>
         <url>scm:git:git@github.com:weld/core.git</url>
-        <tag>5.0.1.Final</tag>
+        <tag>5.0.1.Final.payara-p1-SNAPSHOT</tag>
     </scm>
 
     <profiles>

--- a/bundles/osgi/pom.xml
+++ b/bundles/osgi/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -370,7 +370,7 @@
         <connection>scm:git:git@github.com:weld/core.git</connection>
         <developerConnection>scm:git:git@github.com:weld/core.git</developerConnection>
         <url>scm:git:git@github.com:weld/core.git</url>
-        <tag>5.0.1.payara-p1-SNAPSHOT</tag>
+        <tag>5.0.1.payara-p1</tag>
     </scm>
 
 </project>

--- a/bundles/osgi/pom.xml
+++ b/bundles/osgi/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -370,7 +370,7 @@
         <connection>scm:git:git@github.com:weld/core.git</connection>
         <developerConnection>scm:git:git@github.com:weld/core.git</developerConnection>
         <url>scm:git:git@github.com:weld/core.git</url>
-        <tag>5.0.1.Final.payara-p1-SNAPSHOT</tag>
+        <tag>5.0.1.payara-p1-SNAPSHOT</tag>
     </scm>
 
 </project>

--- a/bundles/osgi/pom.xml
+++ b/bundles/osgi/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -370,7 +370,7 @@
         <connection>scm:git:git@github.com:weld/core.git</connection>
         <developerConnection>scm:git:git@github.com:weld/core.git</developerConnection>
         <url>scm:git:git@github.com:weld/core.git</url>
-        <tag>5.0.1.Final</tag>
+        <tag>5.0.1.Final.payara-p1-SNAPSHOT</tag>
     </scm>
 
 </project>

--- a/docs/reference/pom.xml
+++ b/docs/reference/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.jboss.weld.reference-guide</groupId>
     <artifactId>weld-reference-guide</artifactId>
-    <version>5.0.1.Final</version>
+    <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Weld Reference Guide</name>
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core-parent</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/docs/reference/pom.xml
+++ b/docs/reference/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.jboss.weld.reference-guide</groupId>
     <artifactId>weld-reference-guide</artifactId>
-    <version>5.0.1.payara-p1-SNAPSHOT</version>
+    <version>5.0.1.payara-p1</version>
     <packaging>pom</packaging>
 
     <name>Weld Reference Guide</name>
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core-parent</artifactId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/docs/reference/pom.xml
+++ b/docs/reference/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.jboss.weld.reference-guide</groupId>
     <artifactId>weld-reference-guide</artifactId>
-    <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+    <version>5.0.1.payara-p1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Weld Reference Guide</name>
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core-parent</artifactId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/environments/common/pom.xml
+++ b/environments/common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/environments/common/pom.xml
+++ b/environments/common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/environments/common/pom.xml
+++ b/environments/common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/environments/se/build/pom.xml
+++ b/environments/se/build/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-se-parent</artifactId>
         <groupId>org.jboss.weld.se</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/environments/se/build/pom.xml
+++ b/environments/se/build/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-se-parent</artifactId>
         <groupId>org.jboss.weld.se</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/environments/se/build/pom.xml
+++ b/environments/se/build/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-se-parent</artifactId>
         <groupId>org.jboss.weld.se</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/environments/se/core/pom.xml
+++ b/environments/se/core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-se-parent</artifactId>
         <groupId>org.jboss.weld.se</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/environments/se/core/pom.xml
+++ b/environments/se/core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-se-parent</artifactId>
         <groupId>org.jboss.weld.se</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/environments/se/core/pom.xml
+++ b/environments/se/core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-se-parent</artifactId>
         <groupId>org.jboss.weld.se</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/environments/se/pom.xml
+++ b/environments/se/pom.xml
@@ -10,7 +10,7 @@
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-core-parent</artifactId>
       <relativePath>../../pom.xml</relativePath>
-      <version>5.0.1.payara-p1-SNAPSHOT</version>
+      <version>5.0.1.payara-p1</version>
    </parent>
 
    <modules>

--- a/environments/se/pom.xml
+++ b/environments/se/pom.xml
@@ -10,7 +10,7 @@
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-core-parent</artifactId>
       <relativePath>../../pom.xml</relativePath>
-      <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+      <version>5.0.1.payara-p1-SNAPSHOT</version>
    </parent>
 
    <modules>

--- a/environments/se/pom.xml
+++ b/environments/se/pom.xml
@@ -10,7 +10,7 @@
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-core-parent</artifactId>
       <relativePath>../../pom.xml</relativePath>
-      <version>5.0.1.Final</version>
+      <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
    </parent>
 
    <modules>

--- a/environments/se/tests/pom.xml
+++ b/environments/se/tests/pom.xml
@@ -3,7 +3,7 @@
    <parent>
       <artifactId>weld-se-parent</artifactId>
       <groupId>org.jboss.weld.se</groupId>
-      <version>5.0.1.Final</version>
+      <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
    <modelVersion>4.0.0</modelVersion>

--- a/environments/se/tests/pom.xml
+++ b/environments/se/tests/pom.xml
@@ -3,7 +3,7 @@
    <parent>
       <artifactId>weld-se-parent</artifactId>
       <groupId>org.jboss.weld.se</groupId>
-      <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+      <version>5.0.1.payara-p1-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
    <modelVersion>4.0.0</modelVersion>

--- a/environments/se/tests/pom.xml
+++ b/environments/se/tests/pom.xml
@@ -3,7 +3,7 @@
    <parent>
       <artifactId>weld-se-parent</artifactId>
       <groupId>org.jboss.weld.se</groupId>
-      <version>5.0.1.payara-p1-SNAPSHOT</version>
+      <version>5.0.1.payara-p1</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
    <modelVersion>4.0.0</modelVersion>

--- a/environments/servlet/build/pom.xml
+++ b/environments/servlet/build/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-servlet-parent</artifactId>
         <groupId>org.jboss.weld.servlet</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.weld.servlet</groupId>

--- a/environments/servlet/build/pom.xml
+++ b/environments/servlet/build/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-servlet-parent</artifactId>
         <groupId>org.jboss.weld.servlet</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.weld.servlet</groupId>

--- a/environments/servlet/build/pom.xml
+++ b/environments/servlet/build/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-servlet-parent</artifactId>
         <groupId>org.jboss.weld.servlet</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.weld.servlet</groupId>

--- a/environments/servlet/core/pom.xml
+++ b/environments/servlet/core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-servlet-parent</artifactId>
         <groupId>org.jboss.weld.servlet</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/environments/servlet/core/pom.xml
+++ b/environments/servlet/core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-servlet-parent</artifactId>
         <groupId>org.jboss.weld.servlet</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/environments/servlet/core/pom.xml
+++ b/environments/servlet/core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-servlet-parent</artifactId>
         <groupId>org.jboss.weld.servlet</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/environments/servlet/pom.xml
+++ b/environments/servlet/pom.xml
@@ -10,7 +10,7 @@
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core-parent</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/environments/servlet/pom.xml
+++ b/environments/servlet/pom.xml
@@ -10,7 +10,7 @@
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core-parent</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/environments/servlet/pom.xml
+++ b/environments/servlet/pom.xml
@@ -10,7 +10,7 @@
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core-parent</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
     </parent>
 
     <modules>

--- a/environments/servlet/tests/base/pom.xml
+++ b/environments/servlet/tests/base/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-servlet-parent</artifactId>
         <groupId>org.jboss.weld.servlet</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/environments/servlet/tests/base/pom.xml
+++ b/environments/servlet/tests/base/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-servlet-parent</artifactId>
         <groupId>org.jboss.weld.servlet</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/environments/servlet/tests/base/pom.xml
+++ b/environments/servlet/tests/base/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-servlet-parent</artifactId>
         <groupId>org.jboss.weld.servlet</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/environments/servlet/tests/tomcat/pom.xml
+++ b/environments/servlet/tests/tomcat/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-servlet-parent</artifactId>
         <groupId>org.jboss.weld.servlet</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/environments/servlet/tests/tomcat/pom.xml
+++ b/environments/servlet/tests/tomcat/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-servlet-parent</artifactId>
         <groupId>org.jboss.weld.servlet</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/environments/servlet/tests/tomcat/pom.xml
+++ b/environments/servlet/tests/tomcat/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-servlet-parent</artifactId>
         <groupId>org.jboss.weld.servlet</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/jsf/login/pom.xml
+++ b/examples/jsf/login/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples</groupId>
         <artifactId>weld-examples-parent</artifactId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/examples/jsf/login/pom.xml
+++ b/examples/jsf/login/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples</groupId>
         <artifactId>weld-examples-parent</artifactId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/examples/jsf/login/pom.xml
+++ b/examples/jsf/login/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples</groupId>
         <artifactId>weld-examples-parent</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/examples/jsf/numberguess/pom.xml
+++ b/examples/jsf/numberguess/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples</groupId>
         <artifactId>weld-examples-parent</artifactId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/examples/jsf/numberguess/pom.xml
+++ b/examples/jsf/numberguess/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples</groupId>
         <artifactId>weld-examples-parent</artifactId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/examples/jsf/numberguess/pom.xml
+++ b/examples/jsf/numberguess/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples</groupId>
         <artifactId>weld-examples-parent</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/examples/jsf/pastecode/pom.xml
+++ b/examples/jsf/pastecode/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples</groupId>
         <artifactId>weld-examples-parent</artifactId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/examples/jsf/pastecode/pom.xml
+++ b/examples/jsf/pastecode/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples</groupId>
         <artifactId>weld-examples-parent</artifactId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/examples/jsf/pastecode/pom.xml
+++ b/examples/jsf/pastecode/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples</groupId>
         <artifactId>weld-examples-parent</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/examples/jsf/translator/ear/pom.xml
+++ b/examples/jsf/translator/ear/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples.jsf.translator</groupId>
         <artifactId>weld-jsf-translator-parent</artifactId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.weld.examples.jsf.translator</groupId>

--- a/examples/jsf/translator/ear/pom.xml
+++ b/examples/jsf/translator/ear/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples.jsf.translator</groupId>
         <artifactId>weld-jsf-translator-parent</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.weld.examples.jsf.translator</groupId>

--- a/examples/jsf/translator/ear/pom.xml
+++ b/examples/jsf/translator/ear/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples.jsf.translator</groupId>
         <artifactId>weld-jsf-translator-parent</artifactId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
     </parent>
 
     <groupId>org.jboss.weld.examples.jsf.translator</groupId>

--- a/examples/jsf/translator/ejb/pom.xml
+++ b/examples/jsf/translator/ejb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples.jsf.translator</groupId>
         <artifactId>weld-jsf-translator-parent</artifactId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.weld.examples.jsf.translator</groupId>

--- a/examples/jsf/translator/ejb/pom.xml
+++ b/examples/jsf/translator/ejb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples.jsf.translator</groupId>
         <artifactId>weld-jsf-translator-parent</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.weld.examples.jsf.translator</groupId>

--- a/examples/jsf/translator/ejb/pom.xml
+++ b/examples/jsf/translator/ejb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples.jsf.translator</groupId>
         <artifactId>weld-jsf-translator-parent</artifactId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
     </parent>
 
     <groupId>org.jboss.weld.examples.jsf.translator</groupId>

--- a/examples/jsf/translator/ftest/pom.xml
+++ b/examples/jsf/translator/ftest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples.jsf.translator</groupId>
         <artifactId>weld-jsf-translator-parent</artifactId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.weld.examples.jsf.translator</groupId>

--- a/examples/jsf/translator/ftest/pom.xml
+++ b/examples/jsf/translator/ftest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples.jsf.translator</groupId>
         <artifactId>weld-jsf-translator-parent</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.weld.examples.jsf.translator</groupId>

--- a/examples/jsf/translator/ftest/pom.xml
+++ b/examples/jsf/translator/ftest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples.jsf.translator</groupId>
         <artifactId>weld-jsf-translator-parent</artifactId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
     </parent>
 
     <groupId>org.jboss.weld.examples.jsf.translator</groupId>

--- a/examples/jsf/translator/pom.xml
+++ b/examples/jsf/translator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.weld.examples</groupId>
         <artifactId>weld-examples-parent</artifactId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.jboss.weld.examples.jsf.translator</groupId>

--- a/examples/jsf/translator/pom.xml
+++ b/examples/jsf/translator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.weld.examples</groupId>
         <artifactId>weld-examples-parent</artifactId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.jboss.weld.examples.jsf.translator</groupId>

--- a/examples/jsf/translator/pom.xml
+++ b/examples/jsf/translator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jboss.weld.examples</groupId>
         <artifactId>weld-examples-parent</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.jboss.weld.examples.jsf.translator</groupId>

--- a/examples/jsf/translator/war/pom.xml
+++ b/examples/jsf/translator/war/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples.jsf.translator</groupId>
         <artifactId>weld-jsf-translator-parent</artifactId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.weld.examples.jsf.translator</groupId>

--- a/examples/jsf/translator/war/pom.xml
+++ b/examples/jsf/translator/war/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples.jsf.translator</groupId>
         <artifactId>weld-jsf-translator-parent</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.weld.examples.jsf.translator</groupId>

--- a/examples/jsf/translator/war/pom.xml
+++ b/examples/jsf/translator/war/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.weld.examples.jsf.translator</groupId>
         <artifactId>weld-jsf-translator-parent</artifactId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
     </parent>
 
     <groupId>org.jboss.weld.examples.jsf.translator</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core-parent</artifactId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.jboss.weld.examples</groupId>
     <artifactId>weld-examples-parent</artifactId>
-  <version>5.0.1.payara-p1-SNAPSHOT</version>
+  <version>5.0.1.payara-p1</version>
     <packaging>pom</packaging>
     <name>Weld Examples</name>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core-parent</artifactId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.jboss.weld.examples</groupId>
     <artifactId>weld-examples-parent</artifactId>
-  <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+  <version>5.0.1.payara-p1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Weld Examples</name>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core-parent</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.jboss.weld.examples</groupId>
     <artifactId>weld-examples-parent</artifactId>
-  <version>5.0.1.Final</version>
+  <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Weld Examples</name>
 

--- a/examples/se/groovy-numberguess/pom.xml
+++ b/examples/se/groovy-numberguess/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-examples-parent</artifactId>
         <groupId>org.jboss.weld.examples</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/se/groovy-numberguess/pom.xml
+++ b/examples/se/groovy-numberguess/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-examples-parent</artifactId>
         <groupId>org.jboss.weld.examples</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/se/groovy-numberguess/pom.xml
+++ b/examples/se/groovy-numberguess/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-examples-parent</artifactId>
         <groupId>org.jboss.weld.examples</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/se/numberguess/pom.xml
+++ b/examples/se/numberguess/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-examples-parent</artifactId>
         <groupId>org.jboss.weld.examples</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/se/numberguess/pom.xml
+++ b/examples/se/numberguess/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-examples-parent</artifactId>
         <groupId>org.jboss.weld.examples</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/se/numberguess/pom.xml
+++ b/examples/se/numberguess/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-examples-parent</artifactId>
         <groupId>org.jboss.weld.examples</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/impl/src/main/java/org/jboss/weld/bean/builtin/BeanManagerBean.java
+++ b/impl/src/main/java/org/jboss/weld/bean/builtin/BeanManagerBean.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Type;
 import java.util.Set;
 
 import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.BeanContainer;
 import jakarta.enterprise.inject.spi.BeanManager;
 
 import org.jboss.weld.bean.BeanIdentifiers;
@@ -29,7 +30,7 @@ import org.jboss.weld.util.collections.Arrays2;
 
 public class BeanManagerBean extends AbstractBuiltInBean<BeanManagerProxy> {
 
-    private static final Set<Type> TYPES = Arrays2.<Type>asSet(Object.class, BeanManager.class);
+    private static final Set<Type> TYPES = Arrays2.<Type>asSet(Object.class, BeanContainer.class, BeanManager.class);
 
     public BeanManagerBean(BeanManagerImpl manager) {
         super(new StringBeanIdentifier(BeanIdentifiers.forBuiltInBean(manager, BeanManager.class, null)), manager, BeanManagerProxy.class);

--- a/impl/src/main/java/org/jboss/weld/bean/builtin/BeanManagerProxy.java
+++ b/impl/src/main/java/org/jboss/weld/bean/builtin/BeanManagerProxy.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import jakarta.enterprise.context.spi.Context;
 import jakarta.enterprise.context.spi.Contextual;
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.Instance;
@@ -281,5 +282,10 @@ public class BeanManagerProxy extends ForwardingBeanManager implements WeldManag
     @Override
     public Collection<Class<? extends Annotation>> getScopes() {
         return delegate().getScopes();
+    }
+
+    @Override
+    public Collection<Context> getContexts(Class<? extends Annotation> scopeType) {
+        return delegate().getContexts(scopeType);
     }
 }

--- a/impl/src/main/java/org/jboss/weld/bootstrap/BeanDeployer.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/BeanDeployer.java
@@ -317,6 +317,13 @@ public class BeanDeployer extends AbstractBeanDeployer<BeanDeployerEnvironment> 
         processBeanAttributes(beans);
     }
 
+    private void processSpecializingBeans(Iterable<? extends AbstractBean<?, ?>> previouslySpecializedBeans) {
+        // For a set of previously specialized beans that are re-enabled, we need to fire PP followed by PBA
+        // Note that this is intentionally different from processBeans() method which also contains PIT event
+        processProducerEvents(previouslySpecializedBeans);
+        processBeanAttributes(previouslySpecializedBeans);
+    }
+
     protected void processBeanAttributes(Iterable<? extends AbstractBean<?, ?>> beans) {
         if (!containerLifecycleEvents.isProcessBeanAttributesObserved()) {
             return;
@@ -344,7 +351,7 @@ public class BeanDeployer extends AbstractBeanDeployer<BeanDeployerEnvironment> 
             getEnvironment().vetoBean(bean);
         }
         // if a specializing bean was vetoed, let's process the specializing bean now
-        processBeans(previouslySpecializedBeans);
+        processSpecializingBeans(previouslySpecializedBeans);
     }
 
     public void createProducersAndObservers() {

--- a/impl/src/main/java/org/jboss/weld/bootstrap/events/AbstractDefinitionContainerEvent.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/events/AbstractDefinitionContainerEvent.java
@@ -17,6 +17,7 @@
 package org.jboss.weld.bootstrap.events;
 
 import org.jboss.weld.exceptions.DefinitionException;
+import org.jboss.weld.exceptions.DeploymentException;
 import org.jboss.weld.logging.BootstrapLogger;
 import org.jboss.weld.manager.BeanManagerImpl;
 import org.jboss.weld.util.Preconditions;
@@ -43,7 +44,12 @@ public abstract class AbstractDefinitionContainerEvent extends AbstractContainer
     public void fire() {
         super.fire();
         if (!getErrors().isEmpty()) {
-            throw new DefinitionException(getErrors());
+            if (getErrors().size() == 1 && getErrors().get(0) instanceof DeploymentException) {
+                // if the throwable was deployment exception, rethrow that
+                    throw (DeploymentException) getErrors().get(0);
+            } else {
+                throw new DefinitionException(getErrors());
+            }
         }
     }
 }

--- a/impl/src/main/java/org/jboss/weld/logging/BootstrapLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/BootstrapLogger.java
@@ -103,7 +103,7 @@ public interface BootstrapLogger extends WeldLogger {
     IllegalStateException unspecifiedRequiredService(Object service, Object target);
 
     @Message(id = 118, value = "Only normal scopes can be passivating. Scope {0}", format = Format.MESSAGE_FORMAT)
-    DefinitionException passivatingNonNormalScopeIllegal(Object param1);
+    DeploymentException passivatingNonNormalScopeIllegal(Object param1);
 
     @LogMessage(level = Level.INFO)
     @Message(id = 119, value = "Not generating any bean definitions from {0} because of underlying class loading error: Type {1} not found.  If this is unexpected, enable DEBUG logging to see the full error.", format = Format.MESSAGE_FORMAT)

--- a/impl/src/main/java/org/jboss/weld/manager/BeanManagerImpl.java
+++ b/impl/src/main/java/org/jboss/weld/manager/BeanManagerImpl.java
@@ -663,7 +663,11 @@ public class BeanManagerImpl implements WeldManager, Serializable {
     }
 
     public Object getReference(Bean<?> bean, Type requestedType, CreationalContext<?> creationalContext, boolean noProxy) {
-        if (creationalContext instanceof CreationalContextImpl<?>) {
+        return getReference(bean, requestedType, creationalContext, noProxy, true);
+    }
+
+    private Object getReference(Bean<?> bean, Type requestedType, CreationalContext<?> creationalContext, boolean noProxy, boolean createChildCc) {
+        if (creationalContext instanceof CreationalContextImpl<?> && createChildCc) {
             creationalContext = ((CreationalContextImpl<?>) creationalContext).getCreationalContext(bean);
         }
         if (!noProxy && isProxyRequired(bean)) {
@@ -700,7 +704,7 @@ public class BeanManagerImpl implements WeldManager, Serializable {
         // Ensure that there is no injection point associated
         final ThreadLocalStackReference<InjectionPoint> stack = currentInjectionPoint.push(EmptyInjectionPoint.INSTANCE);
         try {
-            return getReference(bean, requestedType, creationalContext, false);
+            return getReference(bean, requestedType, creationalContext, false, false);
         } finally {
             stack.pop();
         }

--- a/impl/src/main/java/org/jboss/weld/manager/BeanManagerImpl.java
+++ b/impl/src/main/java/org/jboss/weld/manager/BeanManagerImpl.java
@@ -663,11 +663,7 @@ public class BeanManagerImpl implements WeldManager, Serializable {
     }
 
     public Object getReference(Bean<?> bean, Type requestedType, CreationalContext<?> creationalContext, boolean noProxy) {
-        return getReference(bean, requestedType, creationalContext, noProxy, true);
-    }
-
-    private Object getReference(Bean<?> bean, Type requestedType, CreationalContext<?> creationalContext, boolean noProxy, boolean createChildCc) {
-        if (creationalContext instanceof CreationalContextImpl<?> && createChildCc) {
+        if (creationalContext instanceof CreationalContextImpl<?>) {
             creationalContext = ((CreationalContextImpl<?>) creationalContext).getCreationalContext(bean);
         }
         if (!noProxy && isProxyRequired(bean)) {
@@ -704,7 +700,7 @@ public class BeanManagerImpl implements WeldManager, Serializable {
         // Ensure that there is no injection point associated
         final ThreadLocalStackReference<InjectionPoint> stack = currentInjectionPoint.push(EmptyInjectionPoint.INSTANCE);
         try {
-            return getReference(bean, requestedType, creationalContext, false, false);
+            return getReference(bean, requestedType, creationalContext, false);
         } finally {
             stack.pop();
         }

--- a/impl/src/main/java/org/jboss/weld/manager/BeanManagerImpl.java
+++ b/impl/src/main/java/org/jboss/weld/manager/BeanManagerImpl.java
@@ -630,6 +630,11 @@ public class BeanManagerImpl implements WeldManager, Serializable {
         return activeContext;
     }
 
+    @Override
+    public Collection<Context> getContexts(Class<? extends Annotation> scopeType) {
+         return Collections.unmodifiableList(contexts.get(scopeType));
+    }
+
     public Context getUnwrappedContext(Class<? extends Annotation> scopeType) {
         return PassivatingContextWrapper.unwrap(getContext(scopeType));
     }

--- a/impl/src/main/java/org/jboss/weld/resolution/AbstractAssignabilityRules.java
+++ b/impl/src/main/java/org/jboss/weld/resolution/AbstractAssignabilityRules.java
@@ -54,7 +54,7 @@ public abstract class AbstractAssignabilityRules implements AssignabilityRules {
      * Standard Java covariant assignability rules are applied to all other types of bounds.
      * This is not explicitly mentioned in the specification but is implied.
      */
-    protected Type[] getUppermostTypeVariableBounds(TypeVariable<?> bound) {
+    static Type[] getUppermostTypeVariableBounds(TypeVariable<?> bound) {
         if (bound.getBounds()[0] instanceof TypeVariable<?>) {
             return getUppermostTypeVariableBounds((TypeVariable<?>) bound.getBounds()[0]);
         }

--- a/inject-tck-runner/pom.xml
+++ b/inject-tck-runner/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inject-tck-runner/pom.xml
+++ b/inject-tck-runner/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inject-tck-runner/pom.xml
+++ b/inject-tck-runner/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jboss-as/pom.xml
+++ b/jboss-as/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core-parent</artifactId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -30,7 +30,7 @@
     <properties>
         <!-- We have to explicitly state the project version. We cannot use ${project.version}
         as the release plugin won't deal with double evaluation -->
-        <weld.update.version>5.0.1.Final.payara-p1-SNAPSHOT</weld.update.version>
+        <weld.update.version>5.0.1.payara-p1-SNAPSHOT</weld.update.version>
     </properties>
 
     <dependencies>

--- a/jboss-as/pom.xml
+++ b/jboss-as/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core-parent</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -30,7 +30,7 @@
     <properties>
         <!-- We have to explicitly state the project version. We cannot use ${project.version}
         as the release plugin won't deal with double evaluation -->
-        <weld.update.version>5.0.1.Final</weld.update.version>
+        <weld.update.version>5.0.1.Final.payara-p1-SNAPSHOT</weld.update.version>
     </properties>
 
     <dependencies>

--- a/jboss-as/pom.xml
+++ b/jboss-as/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core-parent</artifactId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -30,7 +30,7 @@
     <properties>
         <!-- We have to explicitly state the project version. We cannot use ${project.version}
         as the release plugin won't deal with double evaluation -->
-        <weld.update.version>5.0.1.payara-p1-SNAPSHOT</weld.update.version>
+        <weld.update.version>5.0.1.payara-p1</weld.update.version>
     </properties>
 
     <dependencies>

--- a/jboss-tck-runner/pom.xml
+++ b/jboss-tck-runner/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jboss-tck-runner/pom.xml
+++ b/jboss-tck-runner/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jboss-tck-runner/pom.xml
+++ b/jboss-tck-runner/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/lang-model-tck/pom.xml
+++ b/lang-model-tck/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/lang-model-tck/pom.xml
+++ b/lang-model-tck/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/lang-model-tck/pom.xml
+++ b/lang-model-tck/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/modules/ejb/pom.xml
+++ b/modules/ejb/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/ejb/pom.xml
+++ b/modules/ejb/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/ejb/pom.xml
+++ b/modules/ejb/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/jsf/pom.xml
+++ b/modules/jsf/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/jsf/pom.xml
+++ b/modules/jsf/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/jsf/pom.xml
+++ b/modules/jsf/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/jta/pom.xml
+++ b/modules/jta/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/jta/pom.xml
+++ b/modules/jta/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/jta/pom.xml
+++ b/modules/jta/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/web/pom.xml
+++ b/modules/web/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/web/pom.xml
+++ b/modules/web/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/web/pom.xml
+++ b/modules/web/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>weld-core-parent</artifactId>
     <packaging>pom</packaging>
-    <version>5.0.1.payara-p1-SNAPSHOT</version>
+    <version>5.0.1.payara-p1</version>
 
     <name>Weld Parent</name>
 
@@ -535,7 +535,7 @@
         <connection>scm:git:git@github.com:weld/core.git</connection>
         <developerConnection>scm:git:git@github.com:weld/core.git</developerConnection>
         <url>scm:git:git@github.com:weld/core.git</url>
-        <tag>5.0.1.payara-p1-SNAPSHOT</tag>
+        <tag>5.0.1.payara-p1</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>weld-core-parent</artifactId>
     <packaging>pom</packaging>
-    <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+    <version>5.0.1.payara-p1-SNAPSHOT</version>
 
     <name>Weld Parent</name>
 
@@ -533,7 +533,7 @@
         <connection>scm:git:git@github.com:weld/core.git</connection>
         <developerConnection>scm:git:git@github.com:weld/core.git</developerConnection>
         <url>scm:git:git@github.com:weld/core.git</url>
-        <tag>5.0.1.Final.payara-p1-SNAPSHOT</tag>
+        <tag>5.0.1.payara-p1-SNAPSHOT</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <!-- Might be used to override the version declared in weld-parent -->
         <!-- build.config.version>9</build.config.version-->
         <!-- Version of the CDI 4.x release TCK -->
-        <cdi.tck-4-0.version>4.0.5</cdi.tck-4-0.version>
+        <cdi.tck-4-0.version>4.0.9</cdi.tck-4-0.version>
         <classfilewriter.version>1.2.5.Final</classfilewriter.version>
         <spotbugs-maven-plugin.version>4.7.0.0</spotbugs-maven-plugin.version>
         <spotbugs-annotations-version>4.7.0</spotbugs-annotations-version>
@@ -100,7 +100,6 @@
         <module>modules/jsf</module>
         <module>modules/jta</module>
         <module>modules/web</module>
-        <module>probe</module>
         <module>bom</module>
     </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <shrinkwrap.descriptors.version>2.0.0</shrinkwrap.descriptors.version>
         <shrinkwrap.resolver.version>3.1.4</shrinkwrap.resolver.version>
         <testng.version>7.4.0</testng.version>
-        <weld.api.version>5.0.SP2</weld.api.version>
+        <weld.api.version>5.0.SP3</weld.api.version>
         <weld.logging.tools.version>1.0.3.Final</weld.logging.tools.version>
         <wildfly.arquillian.version>3.0.1.Final</wildfly.arquillian.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -51,26 +51,28 @@
         <manifest.specification.version>2.0</manifest.specification.version>
 
         <!-- Dependency versions. KEEP IN ALPHABETICAL ORDER -->
-        <apache.bcel.version>6.5.0</apache.bcel.version>
-        <arquillian.version>1.7.0.Alpha10</arquillian.version>
-        <arquillian.drone.version>2.5.5</arquillian.drone.version>
-        <arquillian.graphene.version>2.5.4</arquillian.graphene.version>
+        <apache.bcel.version>6.6.0</apache.bcel.version>
+        <arquillian.version>1.7.0.Alpha12</arquillian.version>
+        <arquillian.drone.version>3.0.0-alpha.5</arquillian.drone.version>
+        <arquillian.graphene.version>3.0.0-alpha.3</arquillian.graphene.version>
         <arquillian.weld.version>3.0.2.Final</arquillian.weld.version>
         <arquillian.se.container.version>1.0.2.Final</arquillian.se.container.version>
         <arquillian.tomcat.version>1.2.0.Final</arquillian.tomcat.version>
         <arquillian.jetty.version>1.0.0.Final</arquillian.jetty.version>
         <atinject.tck.version>2.0.1</atinject.tck.version>
-        <!-- Might be used to override the version declared in weld-parent -->
-        <!-- build.config.version>9</build.config.version-->
         <!-- Version of the CDI 4.x release TCK -->
-        <cdi.tck-4-0.version>4.0.9</cdi.tck-4-0.version>
+        <cdi.tck-4-0.version>4.0.10</cdi.tck-4-0.version>
+        <!-- By default, each mvn profile uses corresponding file from TCK repo, see jboss-tck-runner/pom.xml -->
+        <!-- We can also use our own file, needed for relaxed mode testing (see WeldMethodInterceptor) -->
+        <!-- Our variant is under src/test/tck/tck-tests.xml -->
+        <cdi.tck.suite.xml.file></cdi.tck.suite.xml.file>
         <classfilewriter.version>1.2.5.Final</classfilewriter.version>
-        <spotbugs-maven-plugin.version>4.7.0.0</spotbugs-maven-plugin.version>
-        <spotbugs-annotations-version>4.7.0</spotbugs-annotations-version>
-        <groovy.version>3.0.11</groovy.version>
-        <htmlunit.version>2.62.0</htmlunit.version>
+        <spotbugs-maven-plugin.version>4.7.2.0</spotbugs-maven-plugin.version>
+        <spotbugs-annotations-version>4.7.2</spotbugs-annotations-version>
+        <groovy.version>3.0.13</groovy.version>
+        <htmlunit.version>2.64.0</htmlunit.version>
         <jacoco.version>0.8.8</jacoco.version>
-        <jandex.version>2.4.2.Final</jandex.version>
+        <jandex.version>2.4.3.Final</jandex.version>
         <jakarta.activation.version>2.1.0</jakarta.activation.version>
         <jakarta.el.version>5.0.1</jakarta.el.version>
         <glassfish.jakarta.el.version>5.0.0-M1</glassfish.jakarta.el.version>
@@ -90,7 +92,7 @@
         <testng.version>7.4.0</testng.version>
         <weld.api.version>5.0.SP3</weld.api.version>
         <weld.logging.tools.version>1.0.3.Final</weld.logging.tools.version>
-        <wildfly.arquillian.version>3.0.1.Final</wildfly.arquillian.version>
+        <wildfly.arquillian.version>5.0.0.Alpha5</wildfly.arquillian.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>weld-core-parent</artifactId>
     <packaging>pom</packaging>
-    <version>5.0.1.Final</version>
+    <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
 
     <name>Weld Parent</name>
 
@@ -533,7 +533,7 @@
         <connection>scm:git:git@github.com:weld/core.git</connection>
         <developerConnection>scm:git:git@github.com:weld/core.git</developerConnection>
         <url>scm:git:git@github.com:weld/core.git</url>
-        <tag>5.0.1.Final</tag>
+        <tag>5.0.1.Final.payara-p1-SNAPSHOT</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
         <module>modules/jsf</module>
         <module>modules/jta</module>
         <module>modules/web</module>
+        <module>probe</module>
         <module>bom</module>
     </modules>
 

--- a/porting-package/pom.xml
+++ b/porting-package/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/porting-package/pom.xml
+++ b/porting-package/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/porting-package/pom.xml
+++ b/porting-package/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/probe/core/pom.xml
+++ b/probe/core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-probe-parent</artifactId>
         <groupId>org.jboss.weld.probe</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/probe/core/pom.xml
+++ b/probe/core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-probe-parent</artifactId>
         <groupId>org.jboss.weld.probe</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/probe/core/pom.xml
+++ b/probe/core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-probe-parent</artifactId>
         <groupId>org.jboss.weld.probe</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/probe/pom.xml
+++ b/probe/pom.xml
@@ -10,7 +10,7 @@
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
     </parent>
 
     <description>Weld's inspection and debugging support</description>

--- a/probe/pom.xml
+++ b/probe/pom.xml
@@ -10,7 +10,7 @@
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
     </parent>
 
     <description>Weld's inspection and debugging support</description>

--- a/probe/pom.xml
+++ b/probe/pom.xml
@@ -10,7 +10,7 @@
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
     </parent>
 
     <description>Weld's inspection and debugging support</description>

--- a/probe/tests/pom.xml
+++ b/probe/tests/pom.xml
@@ -3,14 +3,14 @@
     <parent>
         <artifactId>weld-probe-parent</artifactId>
         <groupId>org.jboss.weld.probe</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.weld.probe</groupId>
     <artifactId>weld-probe-tests</artifactId>
-    <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+    <version>5.0.1.payara-p1-SNAPSHOT</version>
 
     <properties>
         <json.version>1.1.4</json.version>

--- a/probe/tests/pom.xml
+++ b/probe/tests/pom.xml
@@ -3,14 +3,14 @@
     <parent>
         <artifactId>weld-probe-parent</artifactId>
         <groupId>org.jboss.weld.probe</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.weld.probe</groupId>
     <artifactId>weld-probe-tests</artifactId>
-    <version>5.0.1.payara-p1-SNAPSHOT</version>
+    <version>5.0.1.payara-p1</version>
 
     <properties>
         <json.version>1.1.4</json.version>

--- a/probe/tests/pom.xml
+++ b/probe/tests/pom.xml
@@ -3,14 +3,14 @@
     <parent>
         <artifactId>weld-probe-parent</artifactId>
         <groupId>org.jboss.weld.probe</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.weld.probe</groupId>
     <artifactId>weld-probe-tests</artifactId>
-    <version>5.0.1.Final</version>
+    <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
 
     <properties>
         <json.version>1.1.4</json.version>

--- a/tests-arquillian/pom.xml
+++ b/tests-arquillian/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests-arquillian/pom.xml
+++ b/tests-arquillian/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests-arquillian/pom.xml
+++ b/tests-arquillian/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/DuplicateRecursion.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/DuplicateRecursion.java
@@ -1,0 +1,9 @@
+package org.jboss.weld.tests.assignability.recursiveGenerics;
+
+public class DuplicateRecursion {
+    interface FooBar<T extends FooBar<?, U>, U extends Comparable<U>> {
+    }
+
+    static class FooBarImpl implements FooBar<FooBarImpl, String> {
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/MutualRecursion.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/MutualRecursion.java
@@ -1,0 +1,21 @@
+package org.jboss.weld.tests.assignability.recursiveGenerics;
+
+public class MutualRecursion {
+    interface Graph<G extends Graph<G, E, N>, E extends Edge<G, E, N>, N extends Node<G, E, N>> {
+    }
+
+    interface Edge<G extends Graph<G, E, N>, E extends Edge<G, E, N>, N extends Node<G, E, N>> {
+    }
+
+    interface Node<G extends Graph<G, E, N>, E extends Edge<G, E, N>, N extends Node<G, E, N>> {
+    }
+
+    static class Map implements Graph<Map, Route, City> {
+    }
+
+    static class Route implements Edge<Map, Route, City> {
+    }
+
+    static class City implements Node<Map, Route, City> {
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/RecursiveGenericProducer.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/RecursiveGenericProducer.java
@@ -1,0 +1,18 @@
+package org.jboss.weld.tests.assignability.recursiveGenerics;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Dependent
+public class RecursiveGenericProducer {
+
+    @Produces
+    @Dependent
+    <T extends Comparable<T>> List<T> produce() {
+        return new ArrayList<T>();
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/RecursiveGenericProducer.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/RecursiveGenericProducer.java
@@ -2,6 +2,10 @@ package org.jboss.weld.tests.assignability.recursiveGenerics;
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
+import org.jboss.weld.tests.assignability.recursiveGenerics.DuplicateRecursion.FooBar;
+import org.jboss.weld.tests.assignability.recursiveGenerics.MutualRecursion.Edge;
+import org.jboss.weld.tests.assignability.recursiveGenerics.MutualRecursion.Graph;
+import org.jboss.weld.tests.assignability.recursiveGenerics.MutualRecursion.Node;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,4 +19,15 @@ public class RecursiveGenericProducer {
         return new ArrayList<T>();
     }
 
+    @Produces
+    @Dependent
+    <T extends FooBar<T, U>, U extends Comparable<U>> FooBar<T, U> produceFooBar() {
+        return null;
+    }
+
+    @Produces
+    @Dependent
+    <G extends Graph<G, E, N>, E extends Edge<G, E, N>, N extends Node<G, E, N>> Graph<G, E, N> produceGraph() {
+        return null;
+    }
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/RecursiveGenericsAssignabilityTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/RecursiveGenericsAssignabilityTest.java
@@ -1,0 +1,47 @@
+package org.jboss.weld.tests.assignability.recursiveGenerics;
+
+import static org.junit.Assert.assertEquals;
+
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.util.TypeLiteral;
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ *
+ */
+@SuppressWarnings("serial")
+@RunWith(Arquillian.class)
+public class RecursiveGenericsAssignabilityTest {
+
+    @Inject
+    private BeanManager beanManager;
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(RecursiveGenericsAssignabilityTest.class))
+            .addPackage(RecursiveGenericsAssignabilityTest.class.getPackage());
+    }
+
+    @Test
+    public <T extends Comparable<T>> void testResursiveGenericAssignability() {
+        // @Inject List<String> should work
+        Set<Bean<?>> beans = beanManager.getBeans(new TypeLiteral<List<String>>(){}.getType());
+        assertEquals(1, beans.size());
+
+        // @Inject List<Object> should NOT work, Object is not Comparable
+        beans = beanManager.getBeans(new TypeLiteral<List<Object>>(){}.getType());
+        assertEquals(0, beans.size());
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/RecursiveGenericsAssignabilityTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/RecursiveGenericsAssignabilityTest.java
@@ -12,15 +12,18 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.BeanArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.weld.test.util.Utils;
+import org.jboss.weld.tests.assignability.recursiveGenerics.DuplicateRecursion.FooBar;
+import org.jboss.weld.tests.assignability.recursiveGenerics.DuplicateRecursion.FooBarImpl;
+import org.jboss.weld.tests.assignability.recursiveGenerics.MutualRecursion.City;
+import org.jboss.weld.tests.assignability.recursiveGenerics.MutualRecursion.Graph;
+import org.jboss.weld.tests.assignability.recursiveGenerics.MutualRecursion.Map;
+import org.jboss.weld.tests.assignability.recursiveGenerics.MutualRecursion.Route;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.List;
 import java.util.Set;
 
-/**
- *
- */
 @SuppressWarnings("serial")
 @RunWith(Arquillian.class)
 public class RecursiveGenericsAssignabilityTest {
@@ -35,7 +38,7 @@ public class RecursiveGenericsAssignabilityTest {
     }
 
     @Test
-    public <T extends Comparable<T>> void testResursiveGenericAssignability() {
+    public void testResursiveGenericAssignability() {
         // @Inject List<String> should work
         Set<Bean<?>> beans = beanManager.getBeans(new TypeLiteral<List<String>>(){}.getType());
         assertEquals(1, beans.size());
@@ -43,5 +46,13 @@ public class RecursiveGenericsAssignabilityTest {
         // @Inject List<Object> should NOT work, Object is not Comparable
         beans = beanManager.getBeans(new TypeLiteral<List<Object>>(){}.getType());
         assertEquals(0, beans.size());
+
+        // @Inject FooBar<FooBarImpl, String>> should work
+        beans = beanManager.getBeans(new TypeLiteral<FooBar<FooBarImpl, String>>(){}.getType());
+        assertEquals(1, beans.size());
+
+        // @Inject Graph<Map, Route, City>> should work
+        beans = beanManager.getBeans(new TypeLiteral<Graph<Map, Route, City>>(){}.getType());
+        assertEquals(1, beans.size());
     }
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/beanContainer/BeanContainerInjectionTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/beanContainer/BeanContainerInjectionTest.java
@@ -1,0 +1,47 @@
+package org.jboss.weld.tests.beanManager.beanContainer;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.BeanContainer;
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Simple test which verifies that we can provide {@link BeanContainer} as a built-in bean
+ */
+@RunWith(Arquillian.class)
+public class BeanContainerInjectionTest {
+
+    @Deployment
+    public static Archive<?> getDeployment() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(BeanContainerInjectionTest.class))
+                .addPackage(BeanContainerInjectionTest.class.getPackage());
+    }
+
+    @Inject
+    MyBean myBean;
+
+    @Inject
+    Instance<Object> instance;
+
+    @Test
+    public void testInjectionOfBeanContainerType() {
+        // bean injection; use the container for arbitrary action
+        myBean.getBeanContainer().isNormalScope(ApplicationScoped.class);
+
+        // dynamic resolution, verify type, explicit qualifier and test scope
+        Instance<BeanContainer> beanContainerInstance = instance.select(BeanContainer.class, Default.Literal.INSTANCE);
+        Assert.assertTrue(beanContainerInstance.isResolvable());
+        Assert.assertEquals(beanContainerInstance.getHandle().getBean().getScope(), Dependent.class);
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/beanContainer/MyBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/beanContainer/MyBean.java
@@ -1,0 +1,16 @@
+package org.jboss.weld.tests.beanManager.beanContainer;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.BeanContainer;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class MyBean {
+
+    @Inject
+    BeanContainer beanContainer;
+
+    public BeanContainer getBeanContainer() {
+        return beanContainer;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/getReference/interceptor/ManualInterceptorInstanceRetrievalTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/getReference/interceptor/ManualInterceptorInstanceRetrievalTest.java
@@ -1,0 +1,46 @@
+package org.jboss.weld.tests.beanManager.getReference.interceptor;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.InterceptionType;
+import jakarta.enterprise.inject.spi.Interceptor;
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+/**
+ * NOTE: The functionality tested here (using BM#getReference for interceptor instances) isn't rooted in CDI spec but
+ * seems to be something intergrators have relied on in the past. One such example is GF resolving interceptors as part
+ * of their EJB integration. Another case used to be MP REST using this to simulate their own interceptor chain.
+ */
+@RunWith(Arquillian.class)
+public class ManualInterceptorInstanceRetrievalTest {
+
+    @Deployment
+    public static Archive<?> getDeployment() {
+        return ShrinkWrap.create(BeanArchive.class,
+                Utils.getDeploymentNameAsHash(ManualInterceptorInstanceRetrievalTest.class)).addPackage(ManualInterceptorInstanceRetrievalTest.class.getPackage());
+    }
+
+    @Inject
+    BeanManager bm;
+
+    @Test
+    public void testGetReferenceForInterceptorInstance() {
+        List<Interceptor<?>> interceptors = bm.resolveInterceptors(InterceptionType.AROUND_INVOKE, MyBinding.Literal.INSTANCE);
+        Assert.assertTrue(interceptors.size() == 1);
+        Interceptor<?> interceptor = interceptors.get(0);
+        CreationalContext<?> creationalContext = bm.createCreationalContext(interceptor);
+        Object reference = bm.getReference(interceptor, MyInterceptor.class, creationalContext);
+        Assert.assertNotNull(reference);
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/getReference/interceptor/MyBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/getReference/interceptor/MyBean.java
@@ -1,0 +1,12 @@
+package org.jboss.weld.tests.beanManager.getReference.interceptor;
+
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+@MyBinding
+public class MyBean {
+
+    public void ping() {
+
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/getReference/interceptor/MyBinding.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/getReference/interceptor/MyBinding.java
@@ -1,0 +1,21 @@
+package org.jboss.weld.tests.beanManager.getReference.interceptor;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.interceptor.InterceptorBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@InterceptorBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+public @interface MyBinding {
+
+    public static class Literal extends AnnotationLiteral<MyBinding> implements MyBinding {
+
+        public static final Literal INSTANCE = new Literal();
+
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/getReference/interceptor/MyInterceptor.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/getReference/interceptor/MyInterceptor.java
@@ -1,0 +1,24 @@
+package org.jboss.weld.tests.beanManager.getReference.interceptor;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Intercepted;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+@Interceptor
+@Priority(1)
+@MyBinding
+public class MyInterceptor {
+
+    @Inject
+    @Intercepted
+    Bean<?> bean;
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ic) throws Exception {
+        return ic.proceed();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/getReference/synthBean/Child.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/getReference/synthBean/Child.java
@@ -1,0 +1,4 @@
+package org.jboss.weld.tests.beanManager.getReference.synthBean;
+
+public class Child {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/getReference/synthBean/MyExtension.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/getReference/synthBean/MyExtension.java
@@ -1,0 +1,52 @@
+package org.jboss.weld.tests.beanManager.getReference.synthBean;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.inject.Singleton;
+
+public class MyExtension implements Extension {
+
+    public static boolean childCreated;
+    public static boolean childDestroyed;
+    public static boolean parentCreated;
+    public static boolean parentDestroyed;
+
+    final void registerBeans(@Observes final AfterBeanDiscovery event, final BeanManager bm) {
+        event.addBean()
+                .addTransitiveTypeClosure(Child.class)
+                .scope(Dependent.class)
+                .createWith((CreationalContext<Child> cc) -> createChild(cc))
+                .destroyWith((child, cc) -> destroyChild(cc));
+        event.addBean()
+                .addTransitiveTypeClosure(Parent.class)
+                .scope(Singleton.class)
+                .createWith((CreationalContext<Parent> cc) -> createParent(bm, cc))
+                .destroyWith((parent, cc) -> destroyParent(cc));
+    }
+
+    private Child createChild(final CreationalContext<Child> cc) {
+        final Child c = new Child();
+        this.childCreated = true;
+        return c;
+    }
+
+    private void destroyChild(CreationalContext<Child> cc) {
+        this.childDestroyed = true;
+        cc.release();
+    }
+
+    private Parent createParent(final BeanManager bm, final CreationalContext<Parent> cc) {
+        final Parent p = new Parent((Child)bm.getReference(bm.resolve(bm.getBeans(Child.class)), Child.class, cc));
+        this.parentCreated = true;
+        return p;
+    }
+
+    private void destroyParent(final CreationalContext<Parent> cc) {
+        this.parentDestroyed = true;
+        cc.release();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/getReference/synthBean/Parent.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/getReference/synthBean/Parent.java
@@ -1,0 +1,11 @@
+package org.jboss.weld.tests.beanManager.getReference.synthBean;
+
+public class Parent {
+
+    private final Child child;
+
+    Parent(final Child child) {
+        super();
+        this.child = child;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/getReference/synthBean/SimulateSynthBeanCreationalContextHierarchyTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/beanManager/getReference/synthBean/SimulateSynthBeanCreationalContextHierarchyTest.java
@@ -1,0 +1,53 @@
+package org.jboss.weld.tests.beanManager.getReference.synthBean;
+
+import static org.junit.Assert.assertTrue;
+
+import jakarta.enterprise.context.spi.AlterableContext;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * NOTE: The functionality this test asserts is not explicitly stated in the spec but it turned out to be relied on in
+ * some cases. We therefore want to have a test coverage for it.
+ * <p>
+ * This test aims to create two synthetic beans and use their creational context to create a link between then so that
+ * once one gets destroyed, so should the other.
+ */
+@RunWith(Arquillian.class)
+public class SimulateSynthBeanCreationalContextHierarchyTest {
+
+    @Deployment
+    public static Archive<?> getDeployment() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(SimulateSynthBeanCreationalContextHierarchyTest.class))
+                .addPackage(SimulateSynthBeanCreationalContextHierarchyTest.class.getPackage())
+                .addAsServiceProvider(Extension.class, MyExtension.class);
+    }
+
+    @Inject
+    BeanManager bm;
+
+    @Test
+    public void testSimulatingCCHierarchyOnSyntBeans() {
+        final Bean<Parent> pb = (Bean<Parent>) bm.resolve(bm.getBeans(Parent.class));
+        final CreationalContext<Parent> pcc = bm.createCreationalContext(pb);
+        final Parent p = (Parent) bm.getReference(pb, Parent.class, pcc);
+        assertTrue(MyExtension.parentCreated);
+        assertTrue(MyExtension.childCreated);
+        final AlterableContext singletonContext = (AlterableContext) bm.getContext(Singleton.class);
+        singletonContext.destroy(pb);
+        assertTrue(MyExtension.parentDestroyed);
+        assertTrue(MyExtension.childDestroyed);
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/BuiltinMetadataBeanTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/BuiltinMetadataBeanTest.java
@@ -74,7 +74,7 @@ public class BuiltinMetadataBeanTest {
 
         Bean<Yoghurt> probioticYoghurtBean = cast(manager.resolve(manager.getBeans(Yoghurt.class, new Probiotic.Literal())));
         CreationalContext<Yoghurt> probioticCtx = manager.createCreationalContext(probioticYoghurtBean);
-        Yoghurt probioticYoghurt = cast(manager.getReference(probioticYoghurtBean, Yoghurt.class, fruitCtx));
+        Yoghurt probioticYoghurt = cast(manager.getReference(probioticYoghurtBean, Yoghurt.class, probioticCtx));
         assertEquals(probioticYoghurtBean, factory.getProbioticYoghurtBean());
     }
 

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/dependent/AccountTransaction.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/dependent/AccountTransaction.java
@@ -1,0 +1,18 @@
+package org.jboss.weld.tests.contexts.dependent;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.Dependent;
+
+@Transactional
+@Dependent
+public class AccountTransaction {
+    public static boolean destroyed = false;
+
+    public void execute() {
+    }
+
+    @PreDestroy
+    public void destroy() {
+        destroyed = true;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/dependent/DependentContextTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/dependent/DependentContextTest.java
@@ -1,0 +1,61 @@
+package org.jboss.weld.tests.contexts.dependent;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Set;
+
+/**
+ * Aims to indirectly verify that interceptors are dependent instances of beans they intercept.
+ */
+@RunWith(Arquillian.class)
+public class DependentContextTest {
+
+    @Deployment
+    public static Archive<?> getDeployment() {
+        return ShrinkWrap.create(BeanArchive.class,
+                Utils.getDeploymentNameAsHash(DependentContextTest.class)).addPackage(DependentContextTest.class.getPackage());
+    }
+
+    @Inject
+    BeanManager bm;
+
+    @Test
+    public void testDependentScopedInterceptorsAreDependentObjectsOfBean() {
+        // since interceptors can't declare `@PreDestroy` callbacks for themselves, we inject
+        // another dependent-scoped bean into the interceptor and add a `@PreDestroy` callback
+        // there -- this dependency will be a dependent instance of the interceptor, and so
+        // if destroying the intercepted bean will destroy the other bean, we have a proof
+        // that the interceptor was also destroyed
+
+        AccountTransaction.destroyed = false;
+        TransactionalInterceptorDependency.destroyed = false;
+        TransactionalInterceptor.intercepted = false;
+
+        Set<Bean<?>> beans = bm.getBeans(AccountTransaction.class);
+        Assert.assertTrue(beans.size() == 1);
+        Bean<AccountTransaction> bean = (Bean<AccountTransaction>) beans.iterator().next();
+        CreationalContext<AccountTransaction> ctx = bm.createCreationalContext(bean);
+
+        AccountTransaction trans = (AccountTransaction) bm.getReference(bean, AccountTransaction.class, ctx);
+        trans.execute();
+
+        assert TransactionalInterceptor.intercepted;
+
+        bean.destroy(trans, ctx);
+
+        Assert.assertTrue(AccountTransaction.destroyed);
+        Assert.assertTrue(TransactionalInterceptorDependency.destroyed);
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/dependent/Transactional.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/dependent/Transactional.java
@@ -1,0 +1,18 @@
+package org.jboss.weld.tests.contexts.dependent;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.interceptor.InterceptorBinding;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({ TYPE })
+@Retention(RUNTIME)
+@Documented
+@InterceptorBinding
+public @interface Transactional {
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/dependent/TransactionalInterceptor.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/dependent/TransactionalInterceptor.java
@@ -1,0 +1,25 @@
+package org.jboss.weld.tests.contexts.dependent;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+@Dependent
+@Transactional
+@Interceptor
+@Priority(1)
+public class TransactionalInterceptor {
+    public static boolean intercepted = false;
+
+    @Inject
+    TransactionalInterceptorDependency dependency;
+
+    @AroundInvoke
+    public Object alwaysReturnThis(InvocationContext ctx) throws Exception {
+        intercepted = true;
+        return ctx.proceed();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/dependent/TransactionalInterceptorDependency.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/dependent/TransactionalInterceptorDependency.java
@@ -1,0 +1,14 @@
+package org.jboss.weld.tests.contexts.dependent;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+public class TransactionalInterceptorDependency {
+    public static boolean destroyed = false;
+
+    @PreDestroy
+    public void destroy() {
+        destroyed = true;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/retrieval/WeldManagerGetContextsTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/retrieval/WeldManagerGetContextsTest.java
@@ -1,0 +1,50 @@
+package org.jboss.weld.tests.contexts.retrieval;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.context.spi.Context;
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.weld.manager.api.WeldManager;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+
+/**
+ * Tests retrieval of registered instances of contexts for given scope annotations.
+ *
+ * See also https://github.com/jakartaee/cdi/issues/628
+ */
+@RunWith(Arquillian.class)
+public class WeldManagerGetContextsTest {
+
+    @Deployment
+    public static WebArchive getDeployment() {
+        return ShrinkWrap.create(WebArchive.class, Utils.getDeploymentNameAsHash(WeldManagerGetContextsTest.class, Utils.ARCHIVE_TYPE.WAR))
+                .addPackage(WeldManagerGetContextsTest.class.getPackage())
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    WeldManager weldManager;
+
+    @Test
+    public void testContextObjectRetrieval() {
+        // there is only one app context in Weld and is always active
+        Collection<Context> contexts = weldManager.getContexts(ApplicationScoped.class);
+        Assert.assertEquals(1, contexts.size());
+        Assert.assertTrue(contexts.iterator().next().isActive());
+
+        // There are four different req. contexts in Weld, only one is active during the test though
+        contexts = weldManager.getContexts(RequestScoped.class);
+        Assert.assertEquals(4, contexts.size());
+        Assert.assertEquals(1, contexts.stream().filter(c -> c.isActive()).count());
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/enterprise/weld1234/Weld1234Test.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/enterprise/weld1234/Weld1234Test.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -57,9 +56,8 @@ public class Weld1234Test {
         } catch (Exception e) {
         }
 
-        // check if toString() still works
-        String toString = exceptionGenerator.toString();
-        assertTrue(toString.contains("REMOVED"));
+        // Verify that toString() still works
+        exceptionGenerator.toString();
 
         try {
             // check if other methods throw NoSuchEJBException

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/processBeanAttributes/specialization/VerifyingExtension.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/processBeanAttributes/specialization/VerifyingExtension.java
@@ -23,12 +23,14 @@ import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.BeanAttributes;
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.enterprise.inject.spi.ProcessBeanAttributes;
+import jakarta.enterprise.inject.spi.ProcessInjectionTarget;
 
 public class VerifyingExtension implements Extension {
 
     private BeanAttributes<Alpha> alpha;
     private BeanAttributes<Bravo> bravo;
     private BeanAttributes<Charlie> charlie;
+    private int bravoPitInvocations = 0;
 
     public void alpha(@Observes ProcessBeanAttributes<Alpha> event) {
         Set<Type> types = event.getBeanAttributes().getTypes();
@@ -50,6 +52,10 @@ public class VerifyingExtension implements Extension {
         }
     }
 
+    public void pitBravo(@Observes ProcessInjectionTarget<Bravo> bravoPit) {
+        bravoPitInvocations++;
+    }
+
     public BeanAttributes<Alpha> getAlpha() {
         return alpha;
     }
@@ -60,5 +66,9 @@ public class VerifyingExtension implements Extension {
 
     public BeanAttributes<Charlie> getCharlie() {
         return charlie;
+    }
+
+    public int getBravoPitInvocations() {
+        return bravoPitInvocations;
     }
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/processBeanAttributes/specialization/VetoTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/processBeanAttributes/specialization/VetoTest.java
@@ -63,5 +63,8 @@ public class VetoTest {
         assertNull(extension.getAlpha());
         assertNotNull(extension.getBravo());
         assertNotNull(extension.getCharlie());
+
+        // verify that PIT<Bravo> is only fired once even during specialization, see WELD-2742
+        assertEquals(1, extension.getBravoPitInvocations());
     }
 }

--- a/tests-common/pom.xml
+++ b/tests-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests-common/pom.xml
+++ b/tests-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests-common/pom.xml
+++ b/tests-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/weld-lite-extension-translator/pom.xml
+++ b/weld-lite-extension-translator/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/weld-lite-extension-translator/pom.xml
+++ b/weld-lite-extension-translator/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.payara-p1-SNAPSHOT</version>
+        <version>5.0.1.payara-p1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/weld-lite-extension-translator/pom.xml
+++ b/weld-lite-extension-translator/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-core-parent</artifactId>
         <groupId>org.jboss.weld</groupId>
-        <version>5.0.1.Final</version>
+        <version>5.0.1.Final.payara-p1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This is the patch of weld 5.0.1 with all the fixes to pass  CDI tck without removing cdi probe packages. I tested this on local environment with linux using the snapshot version:  5.0.1.payara-p1-SNAPSHOT

![image](https://github.com/user-attachments/assets/4247d798-8616-44f5-9ab4-c95c227a6f85)


once this is approved I will upload the final version as a tag and to the nexus. Then we can continue with the other PR's, listed here: 
Payara PR:

- https://github.com/payara/Payara/pull/7147

cditck-porting

- https://github.com/payara/cditck-porting/pull/20

glassfish porting

- https://github.com/payara/glassfish-cdi-porting-tck/pull/3

jakartaee 10 runner

- https://github.com/payara/jakartaee-10-tck-runners/pull/127
